### PR TITLE
Setup py tweaks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,12 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
+VERSION = '0.1.4'
+
 setup(
   name = 'hospital_logfile_analyzer',
   packages = find_packages(),
-  version = '0.1.4',
+  version = VERSION,
   license='MIT',
   description = 'Tool to convert plain-text hospital integration engines\' log files to structured data',
   long_description=long_description,
@@ -17,7 +19,7 @@ setup(
   author = 'Pavlo Dyban (Doctolib GmbH)',
   author_email = 'pavlo.dyban@doctolib.com',
   url = 'https://github.com/doctolib/hospital_logfile_analyzer',
-  download_url = 'https://github.com/doctolib/hospital_logfile_analyzer/archive/v.0.1.4.tar.gz',
+  download_url = f"https://github.com/doctolib/hospital_logfile_analyzer/archive/v.{VERSION}.tar.gz",
   keywords = ['logfile', 'parser', 'integration engine', 'communication server',
         'HIS', 'hospital', 'information system', 'communication',
         'TCP/IP', 'structured data'],

--- a/setup.py
+++ b/setup.py
@@ -38,4 +38,9 @@ setup(
     'Programming Language :: Python :: 3.8',
   ],
   test_suite="hospital_logfile_analyzer.test",
+  entry_points={
+    'console_scripts': [
+        'hla = hospital_logfile_analyzer.__main__:main',
+    ],
+  },
 )


### PR DESCRIPTION
Just a few small things:

It's probably easier to maintain the version number when it's just in one place.

The entry points add the specified name to your PATH and execute the function you point this name to.

In this case after `pip install`ing, you can invoke your program in the terminal:
```
hla
```

This cuts down on typing and allows you to distribute multiple executables with one package.

Here are some more references on entry points:
- https://chriswarrick.com/blog/2014/09/15/python-apps-the-right-way-entry_points-and-scripts/
- https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation
- https://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins